### PR TITLE
Add documentation about better alternatives for Specs2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ For a basic project template using sbt, see the [simple-example](https://github.
 
 For using full configuration example with `Build.scala`, see the [full-example](https://github.com/AlpineNow/junit_xml_listener/tree/master/src/sbt-test/full-example) project.
 
+Alternatives
+------------
+
+If your tests are written in [`Specs2`](http://etorreborre.github.io/specs2/) then you will get better results from the built in `junitxml` output format than from this SBT plugin.
+
+You should add the following to your `build.sbt`:
+
+    testOptions in Test += Tests.Argument("junitxml")
+
+    testOptions in Test += Tests.Argument("console")
+
+The built in JUnit XML support in Specs2 includes real test names (this project currently only reports "`SuiteSelector.SuiteSelector`" as the name of all tests) and test run durations (currently missing in this project).
+
 Version History
 ---------------
 


### PR DESCRIPTION
I have been using `junit_xml_listener` for a while with Specs2 (and struggling with a few issues), but I recently discovered that Specs2 has built in support for JUnit XML output which works much better than `junit_xml_listener`.

See http://stackoverflow.com/questions/6934868/configuring-junitxml-output-for-specs2-tests-in-sbt-0-10
and http://stackoverflow.com/questions/19033473/how-to-integrate-the-junitxml-listener-to-specs2

To save others the same trouble, I think this could be documented in the project readme (at least until the `junit_xml_listener` support for Specs2 catches up with the built in formatter).
